### PR TITLE
Lack of pretty printing for estimated time

### DIFF
--- a/cmd/nem/main.go
+++ b/cmd/nem/main.go
@@ -214,7 +214,7 @@ func printAccountDetails(chain core.Chain, pair keypair.KeyPair) {
 func formatEstimatedTime(t float64) string {
 	h := uint64(t) / 3600
 	m := (uint64(t) % 3600) / 60
-	s := t - float64(h) * 3600.0 - float64(m) * 60.0
+	s := t - float64(h)*3600.0 - float64(m)*60.0
 
 	return fmt.Sprintf("%v:%v:%.3f", h, m, s)
 }

--- a/cmd/nem/main.go
+++ b/cmd/nem/main.go
@@ -186,8 +186,10 @@ func showAccountEstimate(pbty float64, showCxty bool) {
 	if showCxty {
 		fmt.Printf("Specified search complexity: %v\n", math.Trunc(1.0/pbty))
 	}
-	fmt.Printf("Estimate search times: %.3f sec (50%%), %.3f sec (80%%), %.3f sec (99.9%%)\n",
-		estimate(pbty, 0.5, rate), estimate(pbty, 0.8, rate), estimate(pbty, 0.99, rate))
+	fmt.Printf("Estimate search times: %v (50%%), %v (80%%), %v (99.9%%)\n",
+		formatEstimatedTime(estimate(pbty, 0.5, rate)),
+		formatEstimatedTime(estimate(pbty, 0.8, rate)),
+		formatEstimatedTime(estimate(pbty, 0.99, rate)))
 }
 
 func countKeyPairs(milliseconds time.Duration) int {
@@ -207,6 +209,14 @@ func printAccountDetails(chain core.Chain, pair keypair.KeyPair) {
 	fmt.Println("Address:", pair.Address(chain).PrettyString())
 	fmt.Println("Public key:", hex.EncodeToString(pair.Public))
 	fmt.Println("Private key:", hex.EncodeToString(pair.Private))
+}
+
+func formatEstimatedTime(t float64) string {
+	h := uint64(t) / 3600
+	m := (uint64(t) % 3600) / 60
+	s := t - float64(h) * 3600.0 - float64(m) * 60.0
+
+	return fmt.Sprintf("%v:%v:%.3f", h, m, s)
 }
 
 func estimate(pbty, prec, rate float64) float64 {


### PR DESCRIPTION
Added printing using `hours:min:sec` pattern :
```
 time nem --chain=mainnet account vanity --no-digits  NBCE                                                       
Calculate accounts rate... 28660 accounts/sec            
Estimate search times: 0:0:44.895 (50%), 0:1:44.243 (80%), 0:4:58.276 (99.9%)                                     
----   
```

Fixes #<GitHub issue number> or describe the changes introduced by this PR.

<!--- Put an `x` in all the boxes that apply -->

- [x] I have read the `CONTRIBUTING.md` and `make ci` passes on my machine.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
