### PR TITLE
Vanity address search estimate times strange format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: |
             if [[ -n ${CIRCLE_TAG} ]]; then
               curl -sL https://git.io/goreleaser |
-                bash -s -- --debug --release-notes <(git log --pretty=oneline --abbrev-commit $(git describe --tags --abbrev=0)^.. | grep '^[^ ]* \[')
+                bash -s -- --debug --release-notes <(git log --pretty=oneline --abbrev-commit $(git describe --tags --abbrev=0)^.. | grep -v '^[^ ]* \(Fix\|Merge\)')
             fi
 deployment:
   trigger_tag:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ By participating, you are expected to uphold this code.
 
 Prerequisites are:
 
-* [`git`](https://git-scm.com)
 * `make`
 * [`Go 1.8+`](http://golang.org/doc/install)
 
@@ -53,16 +52,6 @@ $ make fmt && make ci
 ```
 
 Which runs all the formatters, linters and tests.
-
-## Categorized commits
-
-All commits started with `[` will be included to release notes automatically, good candidates are:
-
-* `[FIX]` - bug or other issue fix (non-breaking change which fixes an issue)
-* `[IMPROVEMENT]` - existing feature improvement (non-breaking change which expend some functionality)
-* `[FEATURE]` - new feature (non-breaking change which adds functionality)
-* `[BREAKING]` - breaking change (fix or feature that would cause existing functionality to change)
-* `[MISC]` - not fall under any of the above categories (non-breaking non-functional change)
 
 ## License
 

--- a/docs/00-introduction.md
+++ b/docs/00-introduction.md
@@ -6,7 +6,7 @@ title: Introduction
 
 Main features:
 
-* Generate new accounts for `Mijin`, `mainnet`, `testnet`.
+* Generate new accounts for `mijin`, `mainnet`, `testnet`.
 * Find vanity address by a given list of prefixes.
 
 Quick demo:

--- a/docs/04-guides.md
+++ b/docs/04-guides.md
@@ -48,13 +48,13 @@ If you would like to search for multiple prefixes at the same time and without d
 
 ```console
 $ nem --chain testnet account vanity --show-complexity --no-digits TABC TACB TBAC TBCA TCAB TCBA
-Calculate accounts rate... 19320 accounts/sec
+Calculate accounts rate... 15225 accounts/sec
 Specified search complexity: 1.203836e+06
-Estimate search times: 0:0:43.189 (50%), 0:1:40.281 (80%), 0:4:46.940 (99.9%)
+Estimate search times: 54s (50%), 2m7s (80%), 6m4s (99.9%)
 ----
-Address: TCBAFK-CHFHUL-FNTNTP-PMYOFI-ICEKIV-YGIXSD-IKLG
-Public key: fcd12b631491585921eb8054280ebeaab894f391411ce1377f008fbfd21fb254
-Private key: 7f4d2b4364ed8803ce565fb4ae2b4a97aac73f9c6629c44dcf7dde5c85e6a1af
+Address: TBACRS-TXXWHM-LZYKPI-ULCOZU-WFMVIX-UMVLYT-LMKM
+Public key: bb326c920bb5b42d5d99df602bb82fdcdd922911ef3b46e73af654babba43698
+Private key: 2d9a61cee0a3b210c2cde438b7f620931049320fd8dffbda04e28e9dd0fbfdef
 ```
 
 As you can see from the last output, `nem-toolchain` can show specified search complexity


### PR DESCRIPTION
Start to use output format from `time.Duration` standard library type.

<!--- Put an `x` in all the boxes that apply -->

- [x] I have read the `CONTRIBUTING.md` and `make ci` passes on my machine.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
