### PR TITLE
Impossible to relax requirements for vanity address prefix

### DIFF
--- a/docs/04-guides.md
+++ b/docs/04-guides.md
@@ -35,10 +35,11 @@ Private key: 3caf6c68dbda89f3c760261d76f83d75bf440509f8615395071f11721e498f3e
 
 ## Vanity address
 
-How to find vanity address with predefined prefix `TCGQQK` for `testnet`:
+How to find vanity address with predefined prefix `TCGQQK` for `testnet`
+using a placeholder character `_` and a non-significant delimiter character `-`:
 
 ```console
-$ nem --chain testnet account vanity --skip-estimate TCGQQK
+$ nem --chain testnet account vanity --skip-estimate TCGQQK-______
 Address: TCGQQK-N5HED6-6OQ67Z-2F7GGW-Z66DWV-BFJUW6-F5WC
 Public key: c342dbf7cdd3096c4c3910c511a57049e62847dd5030c7e644bc855acc1fd626
 Private key: 4e017065d62f10223b989ff3f75a845fbe3df73d6c0e6d67cc4c59bea3213002

--- a/pkg/keypair/keypair_test.go
+++ b/pkg/keypair/keypair_test.go
@@ -34,27 +34,27 @@ func TestKeyPair_Address_testnet(t *testing.T) {
 }
 
 func TestParseAddress_length(t *testing.T) {
-	for _, str := range []string{
+	for _, s := range []string{
 		"",
 		"TABC",
 		"TAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",   // not enough (-1)
 		"TAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABC", // to much (+1)
 	} {
-		t.Run(str, func(t *testing.T) {
-			_, err := ParseAddress(str)
+		t.Run(s, func(t *testing.T) {
+			_, err := ParseAddress(s)
 			assert.Error(t, err)
 		})
 	}
 }
 
 func TestParseAddress_encoding(t *testing.T) {
-	for _, str := range []string{
+	for _, s := range []string{
 		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 		"TAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
 		"TAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA_",
 	} {
-		t.Run(str, func(t *testing.T) {
-			_, err := ParseAddress(str)
+		t.Run(s, func(t *testing.T) {
+			_, err := ParseAddress(s)
 			assert.Error(t, err)
 		})
 	}

--- a/pkg/vanity/probability.go
+++ b/pkg/vanity/probability.go
@@ -26,7 +26,7 @@ func NumberOfAttempts(pbty, prec float64) float64 {
 
 // Probability determines a probability to find an address on random basis in one attempt
 func Probability(sel Selector) float64 {
-	res := float64(0)
+	res := 0.
 	for _, rule := range sel.rules() {
 		res += rule.probability()
 	}
@@ -37,46 +37,66 @@ func Probability(sel Selector) float64 {
 }
 
 func (rule searchRule) probability() float64 {
-	res := float64(1)
+	res := 1.
 	if rule.exclude != nil && rule.prefix != nil {
-		res *= rule.prefix.probability() *
-			rule.exclude.probability(uint(len(rule.prefix.prefix)))
+		res *= rule.prefix.probability()
+		if len(rule.prefix.prefix) > 1 && (rule.prefix.prefix[1] != PrefixPlaceholder) {
+			res *= rule.exclude.probability(2,
+				uint(keypair.AddressLength-2-len(strings.Replace(
+					rule.prefix.prefix[2:], string(PrefixPlaceholder), "", -1))))
+		} else {
+			res *= rule.exclude.probability(0,
+				uint(keypair.AddressLength-len(strings.Replace(
+					rule.prefix.prefix[1:], string(PrefixPlaceholder), "", -1))))
+		}
 	} else if rule.exclude != nil {
-		res *= rule.exclude.probability(0)
+		res *= rule.exclude.probability(0, keypair.AddressLength)
 	} else if rule.prefix != nil {
 		res *= rule.prefix.probability()
 	}
 	return res
 }
 
-func (sel excludeSelector) probability(offset uint) float64 {
-	if offset >= keypair.AddressLength {
+func (sel excludeSelector) probability(offset, length uint) float64 {
+	if offset > keypair.AddressLength {
 		panic("wrong vanity selector probability offset")
 	}
-	res := float64(1)
+	if offset+length > keypair.AddressLength {
+		length = keypair.AddressLength - offset
+	}
+	res := 1.
+	if length == 0 {
+		return res
+	}
 	if offset == 0 {
-		offset, res = 1, res*base32FirstPosProbability
+		offset, length, res = 1, length-1, res*base32FirstPosProbability
+	}
+	if length == 0 {
+		return res
 	}
 	if offset == 1 {
-		offset, res = 2, res*(1.-
+		_, length, res = 2, length-1, res*(1.-
 			(float64(len(util.IntersectStrings([]string{"A", "B", "C", "D"},
 				strings.Split(sel.chars, ""))))*base32SecondPosProbability))
 	}
+	if length == 0 {
+		return res
+	}
 	return res *
-		math.Pow(1.-float64(len(sel.chars))*base32OtherPosProbability,
-			float64(keypair.AddressLength-offset))
+		math.Pow(1.-float64(len(sel.chars))*base32OtherPosProbability, float64(length))
 }
 
 func (sel prefixSelector) probability() float64 {
-	res := float64(1)
-	if len(sel.prefix) > 0 {
+	res := 1.
+	if len(sel.prefix) > 0 && (sel.prefix[0] != PrefixPlaceholder) {
 		res *= base32FirstPosProbability
 	}
-	if len(sel.prefix) > 1 {
+	if len(sel.prefix) > 1 && (sel.prefix[1] != PrefixPlaceholder) {
 		res *= base32SecondPosProbability
 	}
 	if len(sel.prefix) > 2 {
-		res *= math.Pow(base32OtherPosProbability, float64(len(sel.prefix)-2))
+		res *= math.Pow(base32OtherPosProbability,
+			float64(len(strings.Replace(sel.prefix[2:], string(PrefixPlaceholder), "", -1))))
 	}
 	return res
 }

--- a/pkg/vanity/probability_test.go
+++ b/pkg/vanity/probability_test.go
@@ -39,34 +39,34 @@ func TestProbability(t *testing.T) {
 
 	assert.InDelta(t, 0.00593, Probability(excludeSelector{"ABC"}), 1e-5)
 	assert.InDelta(t, 0.02374, Probability(excludeSelector{"246"}), 1e-5)
-	assert.InDelta(t, 0.00024, Probability(prefixSelector{"TABC"}), 1e-5)
+	assert.InDelta(t, 0.00024, Probability(prefixSelector{prefix: "TABC"}), 1e-5)
 
 	assert.Equal(t, 1.,
-		Probability(OrSelector(excludeSelector{""}, prefixSelector{""})))
+		Probability(OrSelector(excludeSelector{""}, prefixSelector{prefix: ""})))
 
 	assert.InDelta(t, 0.00469,
 		Probability(AndSelector(
 			OrSelector(excludeSelector{"2"}, excludeSelector{"4"}, excludeSelector{"6"}),
-			excludeSelector{"BCD"}, prefixSelector{"TA"})), 1e-5)
+			excludeSelector{"BCD"}, prefixSelector{prefix: "TA"})), 1e-5)
 }
 
 func TestSearchRule_probability(t *testing.T) {
 	assert.Equal(t, 1., searchRule{}.probability())
 
 	assert.InDelta(t, 0.00593, searchRule{exclude: &excludeSelector{"ABC"}}.probability(), 1e-5)
-	assert.InDelta(t, 0.00024, searchRule{prefix: &prefixSelector{"TABC"}}.probability(), 1e-5)
+	assert.InDelta(t, 0.00024, searchRule{prefix: &prefixSelector{prefix: "TABC"}}.probability(), 1e-5)
 
 	assert.InDelta(t, 0.0000071,
-		searchRule{exclude: &excludeSelector{"ABC"}, prefix: &prefixSelector{"TABC"}}.probability(),
+		searchRule{exclude: &excludeSelector{"ABC"}, prefix: &prefixSelector{prefix: "TABC"}}.probability(),
 		1e-7)
 	assert.InDelta(t, 0.0000071,
-		searchRule{exclude: &excludeSelector{"ABC"}, prefix: &prefixSelector{"TA_B__C"}}.probability(),
+		searchRule{exclude: &excludeSelector{"ABC"}, prefix: &prefixSelector{prefix: "TA_B__C"}}.probability(),
 		1e-7)
 	assert.InDelta(t, 0.00000024,
-		searchRule{exclude: &excludeSelector{"ABC"}, prefix: &prefixSelector{"T_A__B___C"}}.probability(),
+		searchRule{exclude: &excludeSelector{"ABC"}, prefix: &prefixSelector{prefix: "T_A__B___C"}}.probability(),
 		1e-8)
 	assert.InDelta(t, 0.00000073,
-		searchRule{exclude: &excludeSelector{"A234"}, prefix: &prefixSelector{"T_A__B___C"}}.probability(),
+		searchRule{exclude: &excludeSelector{"A234"}, prefix: &prefixSelector{prefix: "T_A__B___C"}}.probability(),
 		1e-8)
 }
 
@@ -99,10 +99,10 @@ func TestExcludePrefix_probability_panic(t *testing.T) {
 
 func TestPrefixPrefix_probability(t *testing.T) {
 	assert.Equal(t, 1., prefixSelector{}.probability())
-	assert.Equal(t, 1., prefixSelector{"T"}.probability())
-	assert.Equal(t, .25, prefixSelector{"TA"}.probability())
+	assert.Equal(t, 1., prefixSelector{prefix: "T"}.probability())
+	assert.Equal(t, .25, prefixSelector{prefix: "TA"}.probability())
 
-	assert.InDelta(t, 0.00781, prefixSelector{"TAB"}.probability(), 1e-5)
-	assert.InDelta(t, 0.00024, prefixSelector{"TABC"}.probability(), 1e-5)
-	assert.InDelta(t, 0.00024, prefixSelector{"T_A__B___C"}.probability(), 1e-5)
+	assert.InDelta(t, 0.00781, prefixSelector{prefix: "TAB"}.probability(), 1e-5)
+	assert.InDelta(t, 0.00024, prefixSelector{prefix: "TABC"}.probability(), 1e-5)
+	assert.InDelta(t, 0.00024, prefixSelector{prefix: "T_A__B___C"}.probability(), 1e-5)
 }

--- a/pkg/vanity/probability_test.go
+++ b/pkg/vanity/probability_test.go
@@ -79,6 +79,7 @@ func TestExcludePrefix_probability(t *testing.T) {
 	assert.Equal(t, 0.75, excludeSelector{"246A"}.probability(0, 2))
 	assert.Equal(t, 0.75, excludeSelector{"246A"}.probability(1, 1))
 	assert.Equal(t, 0.65625, excludeSelector{"246A"}.probability(1, 2))
+	assert.Equal(t, 0.875, excludeSelector{"246A"}.probability(39, 10))
 
 	assert.InDelta(t, 0.22444,
 		excludeSelector{"A"}.probability(0, keypair.AddressLength), 1e-5)

--- a/pkg/vanity/probability_test.go
+++ b/pkg/vanity/probability_test.go
@@ -8,6 +8,7 @@ import (
 
 	"math"
 
+	"github.com/nem-toolchain/nem-toolchain/pkg/keypair"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,48 +54,63 @@ func TestProbability(t *testing.T) {
 func TestSearchRule_probability(t *testing.T) {
 	assert.Equal(t, 1., searchRule{}.probability())
 
-	assert.InDelta(t, 0.00593, searchRule{exclude: &excludeSelector{"ABC"}}.probability(), 1e-5)
-	assert.InDelta(t, 0.00024, searchRule{prefix: &prefixSelector{prefix: "TABC"}}.probability(), 1e-5)
-
-	assert.InDelta(t, 0.0000071,
-		searchRule{exclude: &excludeSelector{"ABC"}, prefix: &prefixSelector{prefix: "TABC"}}.probability(),
-		1e-7)
-	assert.InDelta(t, 0.0000071,
-		searchRule{exclude: &excludeSelector{"ABC"}, prefix: &prefixSelector{prefix: "TA_B__C"}}.probability(),
-		1e-7)
-	assert.InDelta(t, 0.00000024,
-		searchRule{exclude: &excludeSelector{"ABC"}, prefix: &prefixSelector{prefix: "T_A__B___C"}}.probability(),
-		1e-8)
-	assert.InDelta(t, 0.00000073,
-		searchRule{exclude: &excludeSelector{"A234"}, prefix: &prefixSelector{prefix: "T_A__B___C"}}.probability(),
-		1e-8)
+	assert.InDelta(t, 0.00593,
+		searchRule{exclude: &excludeSelector{"ABC"}}.probability(), 1e-5)
+	assert.InDelta(t, 0.00024,
+		searchRule{prefix: &prefixSelector{prefix: "TA_B__C___"}}.probability(), 1e-5)
+	assert.InDelta(t, 0.000031,
+		searchRule{prefix: &prefixSelector{prefix: "T_A__B___C"}}.probability(), 1e-6)
+	assert.InDelta(t, 0.0000071, searchRule{
+		exclude: &excludeSelector{"ABC"},
+		prefix:  &prefixSelector{prefix: "TA_B__C___"}}.probability(), 1e-7)
+	assert.InDelta(t, 0.00000024, searchRule{
+		exclude: &excludeSelector{"ABC"},
+		prefix:  &prefixSelector{prefix: "T_A__B___C"}}.probability(), 1e-8)
 }
 
 func TestExcludePrefix_probability(t *testing.T) {
-	assert.Equal(t, 1., excludeSelector{}.probability(0))
-	assert.Equal(t, 1., excludeSelector{}.probability(1))
-	assert.Equal(t, 1., excludeSelector{}.probability(2))
-	assert.Equal(t, 1., excludeSelector{}.probability(39))
+	assert.Equal(t, 1., excludeSelector{}.probability(0, keypair.AddressLength))
+	assert.Equal(t, 1., excludeSelector{}.probability(1, keypair.AddressLength-1))
+	assert.Equal(t, 1., excludeSelector{}.probability(2, keypair.AddressLength-2))
+	assert.Equal(t, 1., excludeSelector{}.probability(39, keypair.AddressLength-39))
+	assert.Equal(t, 1., excludeSelector{}.probability(keypair.AddressLength, 0))
 
-	assert.InDelta(t, 0.22444, excludeSelector{"A"}.probability(0), 1e-5)
-	assert.InDelta(t, 0.22444, excludeSelector{"A"}.probability(1), 1e-5)
-	assert.InDelta(t, 0.29926, excludeSelector{"A"}.probability(2), 1e-5)
-	assert.Equal(t, 0.96875, excludeSelector{"A"}.probability(39))
+	assert.Equal(t, 1., excludeSelector{"246A"}.probability(0, 1))
+	assert.Equal(t, 0.75, excludeSelector{"246A"}.probability(0, 2))
+	assert.Equal(t, 0.75, excludeSelector{"246A"}.probability(1, 1))
+	assert.Equal(t, 0.65625, excludeSelector{"246A"}.probability(1, 2))
 
-	assert.InDelta(t, 0.00593, excludeSelector{"ABC"}.probability(0), 1e-5)
-	assert.InDelta(t, 0.00593, excludeSelector{"ABC"}.probability(1), 1e-5)
-	assert.InDelta(t, 0.02374, excludeSelector{"ABC"}.probability(2), 1e-5)
-	assert.Equal(t, 0.90625, excludeSelector{"ABC"}.probability(39))
+	assert.InDelta(t, 0.22444,
+		excludeSelector{"A"}.probability(0, keypair.AddressLength), 1e-5)
+	assert.InDelta(t, 0.22444,
+		excludeSelector{"A"}.probability(1, keypair.AddressLength-1), 1e-5)
+	assert.InDelta(t, 0.29926,
+		excludeSelector{"A"}.probability(2, keypair.AddressLength-2), 1e-5)
+	assert.Equal(t, 0.96875,
+		excludeSelector{"A"}.probability(39, keypair.AddressLength-39))
 
-	assert.InDelta(t, 0.02374, excludeSelector{"246"}.probability(0), 1e-5)
-	assert.InDelta(t, 0.02374, excludeSelector{"246"}.probability(1), 1e-5)
-	assert.InDelta(t, 0.02374, excludeSelector{"246"}.probability(2), 1e-5)
-	assert.InDelta(t, 0.90625, excludeSelector{"246"}.probability(39), 1e-5)
+	assert.InDelta(t, 0.00593,
+		excludeSelector{"ABC"}.probability(0, keypair.AddressLength), 1e-5)
+	assert.InDelta(t, 0.00593,
+		excludeSelector{"ABC"}.probability(1, keypair.AddressLength-1), 1e-5)
+	assert.InDelta(t, 0.02374,
+		excludeSelector{"ABC"}.probability(2, keypair.AddressLength-2), 1e-5)
+	assert.Equal(t, 0.90625,
+		excludeSelector{"ABC"}.probability(39, keypair.AddressLength-39))
+
+	assert.InDelta(t, 0.02374,
+		excludeSelector{"246"}.probability(0, keypair.AddressLength), 1e-5)
+	assert.InDelta(t, 0.02374,
+		excludeSelector{"246"}.probability(1, keypair.AddressLength-1), 1e-5)
+	assert.InDelta(t, 0.02374,
+		excludeSelector{"246"}.probability(2, keypair.AddressLength-2), 1e-5)
+	assert.InDelta(t, 0.90625,
+		excludeSelector{"246"}.probability(39, keypair.AddressLength-39), 1e-5)
 }
 
 func TestExcludePrefix_probability_panic(t *testing.T) {
-	assert.Panics(t, func() { excludeSelector{}.probability(40) })
-	assert.Panics(t, func() { excludeSelector{}.probability(1000) })
+	assert.Panics(t, func() { excludeSelector{}.probability(keypair.AddressLength+1, 0) })
+	assert.Panics(t, func() { excludeSelector{}.probability(1000, 123) })
 }
 
 func TestPrefixPrefix_probability(t *testing.T) {
@@ -104,5 +120,9 @@ func TestPrefixPrefix_probability(t *testing.T) {
 
 	assert.InDelta(t, 0.00781, prefixSelector{prefix: "TAB"}.probability(), 1e-5)
 	assert.InDelta(t, 0.00024, prefixSelector{prefix: "TABC"}.probability(), 1e-5)
-	assert.InDelta(t, 0.00024, prefixSelector{prefix: "T_A__B___C"}.probability(), 1e-5)
+
+	assert.InDelta(t, 0.00098, prefixSelector{prefix: "___B__C___"}.probability(), 1e-5)
+	assert.InDelta(t, 0.00024, prefixSelector{prefix: "_A_B__C___"}.probability(), 1e-5)
+	assert.InDelta(t, 0.00024, prefixSelector{prefix: "TA_B__C___"}.probability(), 1e-5)
+	assert.InDelta(t, 0.000031, prefixSelector{prefix: "T_A__B___C"}.probability(), 1e-6)
 }

--- a/pkg/vanity/search_rule_test.go
+++ b/pkg/vanity/search_rule_test.go
@@ -22,17 +22,19 @@ func TestSearchRule_merge(t *testing.T) {
 		searchRule{exclude: &excludeSelector{}, prefix: &prefixSelector{}},
 		searchRule{exclude: &excludeSelector{}}.merge(searchRule{prefix: &prefixSelector{}}))
 	assert.Equal(t,
-		searchRule{exclude: &excludeSelector{"246"}, prefix: &prefixSelector{"TABC"}},
-		searchRule{exclude: &excludeSelector{"246"}}.merge(searchRule{prefix: &prefixSelector{"TABC"}}))
+		searchRule{exclude: &excludeSelector{"246"}, prefix: &prefixSelector{prefix: "TABC"}},
+		searchRule{exclude: &excludeSelector{"246"}}.merge(searchRule{prefix: &prefixSelector{prefix: "TABC"}}))
 	assert.Equal(t,
-		searchRule{exclude: &excludeSelector{"246BC"}, prefix: &prefixSelector{"TA"}},
-		searchRule{exclude: &excludeSelector{"24"}, prefix: &prefixSelector{"TA"}}.
+		searchRule{exclude: &excludeSelector{"246BC"}, prefix: &prefixSelector{prefix: "TA"}},
+		searchRule{exclude: &excludeSelector{"24"}, prefix: &prefixSelector{prefix: "TA"}}.
 			merge(searchRule{exclude: &excludeSelector{"6BC"}}))
 }
 
 func TestSearchRule_panic(t *testing.T) {
 	assert.Panics(t,
-		func() { searchRule{prefix: &prefixSelector{}}.merge(searchRule{prefix: &prefixSelector{}}) })
+		func() {
+			searchRule{prefix: &prefixSelector{}}.merge(searchRule{prefix: &prefixSelector{}})
+		})
 }
 
 func TestNewExcludeSelector_merge(t *testing.T) {

--- a/pkg/vanity/selector.go
+++ b/pkg/vanity/selector.go
@@ -27,11 +27,14 @@ func NewExcludeSelector(chars string) (Selector, error) {
 
 // NewPrefixSelector creates a new prefix selector from given string
 func NewPrefixSelector(ch core.Chain, prefix string) (Selector, error) {
-	str := fmt.Sprintf(`^%v[A-D][A-Z2-7]*$`, ch.ChainPrefix())
+	prefix = strings.Replace(prefix, "-", "", -1)
+	str := fmt.Sprintf(`^[_%v]?([_A-D][_A-Z2-7]*)?$`, ch.ChainPrefix())
 	if !regexp.MustCompile(str).MatchString(prefix) {
 		return prefixSelector{}, fmt.Errorf("incorrect prefix '%v'", prefix)
 	}
-	return prefixSelector{prefix}, nil
+	regex := regexp.MustCompile(fmt.Sprintf("^%v\\w*",
+		strings.Replace(prefix, "_", "\\w", -1)))
+	return prefixSelector{prefix, regex}, nil
 }
 
 // Selector defines generic search strategy
@@ -58,6 +61,8 @@ type excludeSelector struct {
 type prefixSelector struct {
 	// prefix determines a required address prefix to search
 	prefix string
+	// re caches a regexp.Regexp object for given prefix
+	re *regexp.Regexp
 }
 
 // Pass returns always false
@@ -82,7 +87,7 @@ func (TrueSelector) rules() []searchRule {
 
 // Pass returns true only if address doesn't contain any digits
 func (sel excludeSelector) Pass(addr keypair.Address) bool {
-	return !strings.ContainsAny(addr.String()[1:], sel.chars)
+	return !strings.ContainsAny(addr.String(), sel.chars)
 }
 
 func (sel excludeSelector) rules() []searchRule {
@@ -91,7 +96,7 @@ func (sel excludeSelector) rules() []searchRule {
 
 // Pass returns true only if address has a given prefix
 func (sel prefixSelector) Pass(addr keypair.Address) bool {
-	return strings.HasPrefix(addr.String(), sel.prefix)
+	return sel.re.MatchString(addr.String())
 }
 
 func (sel prefixSelector) rules() []searchRule {

--- a/pkg/vanity/selector.go
+++ b/pkg/vanity/selector.go
@@ -15,6 +15,10 @@ import (
 	"github.com/nem-toolchain/nem-toolchain/pkg/util"
 )
 
+const (
+	PrefixPlaceholder = '_'
+)
+
 // NewExcludeSelector creates a new exclude selector from given string
 func NewExcludeSelector(chars string) (Selector, error) {
 	if !regexp.MustCompile(`^[A-Z2-7]*$`).MatchString(chars) {

--- a/pkg/vanity/selector_combi_test.go
+++ b/pkg/vanity/selector_combi_test.go
@@ -20,11 +20,11 @@ func TestSeqMultiSelector_Pass_true(t *testing.T) {
 	assert.True(t, seqSelector{[]Selector{TrueSelector{}, TrueSelector{}}}.Pass(addr))
 	assert.True(t, seqSelector{[]Selector{excludeSelector{"234567"}}}.Pass(addr))
 	assert.True(t, seqSelector{[]Selector{
-		prefixSelector{re: regexp.MustCompile("^TAA")},
+		prefixSelector{re: regexp.MustCompile(`^TAA`)},
 	}}.Pass(addr))
 	assert.True(t, seqSelector{[]Selector{
 		excludeSelector{"BCD"},
-		prefixSelector{re: regexp.MustCompile("^TA")},
+		prefixSelector{re: regexp.MustCompile(`^TA`)},
 	}}.Pass(addr))
 }
 
@@ -35,15 +35,15 @@ func TestSeqMultiSelector_Pass_false(t *testing.T) {
 	assert.False(t, seqSelector{[]Selector{TrueSelector{}, FalseSelector{}}}.Pass(addr))
 	assert.False(t, seqSelector{[]Selector{excludeSelector{"ABC"}}}.Pass(addr))
 	assert.False(t, seqSelector{[]Selector{
-		prefixSelector{re: regexp.MustCompile("^TB")},
+		prefixSelector{re: regexp.MustCompile(`^TB`)},
 	}}.Pass(addr))
 	assert.False(t, seqSelector{[]Selector{
 		excludeSelector{"BCD"},
-		prefixSelector{re: regexp.MustCompile("^TB")},
+		prefixSelector{re: regexp.MustCompile(`^TB`)},
 	}}.Pass(addr))
 	assert.False(t, seqSelector{[]Selector{
 		excludeSelector{"ABC"},
-		prefixSelector{re: regexp.MustCompile("^TA")},
+		prefixSelector{re: regexp.MustCompile(`^TA`)},
 	}}.Pass(addr))
 }
 
@@ -87,11 +87,11 @@ func TestParMultiSelector_Pass_true(t *testing.T) {
 	assert.True(t, parSelector{[]Selector{excludeSelector{"234567"}}}.Pass(addr))
 	assert.True(t, parSelector{[]Selector{
 		excludeSelector{"BCD"},
-		prefixSelector{re: regexp.MustCompile("^TB")},
+		prefixSelector{re: regexp.MustCompile(`^TB`)},
 	}}.Pass(addr))
 	assert.True(t, parSelector{[]Selector{
 		excludeSelector{"ABC"},
-		prefixSelector{re: regexp.MustCompile("^TA")},
+		prefixSelector{re: regexp.MustCompile(`^TA`)},
 	}}.Pass(addr))
 }
 
@@ -101,11 +101,11 @@ func TestParMultiSelector_Pass_false(t *testing.T) {
 	assert.False(t, parSelector{[]Selector{FalseSelector{}}}.Pass(addr))
 	assert.False(t, parSelector{[]Selector{excludeSelector{"ABC"}}}.Pass(addr))
 	assert.False(t, parSelector{[]Selector{
-		prefixSelector{re: regexp.MustCompile("^TB")},
+		prefixSelector{re: regexp.MustCompile(`^TB`)},
 	}}.Pass(addr))
 	assert.False(t, parSelector{[]Selector{
 		excludeSelector{"ABC"},
-		prefixSelector{re: regexp.MustCompile("^TB")},
+		prefixSelector{re: regexp.MustCompile(`^TB`)},
 	}}.Pass(addr))
 }
 

--- a/pkg/vanity/selector_test.go
+++ b/pkg/vanity/selector_test.go
@@ -48,23 +48,23 @@ func TestNewPrefixSelector(t *testing.T) {
 		pr string
 		re *regexp.Regexp
 	}{
-		"":  {core.Mijin, "", regexp.MustCompile("^\\w*")},
-		"M": {core.Mijin, "M", regexp.MustCompile("^M\\w*")},
-		"_": {core.Mijin, "_", regexp.MustCompile("^\\w\\w*")},
+		"":  {core.Mijin, "", regexp.MustCompile(`^\w*`)},
+		"M": {core.Mijin, "M", regexp.MustCompile(`^M\w*`)},
+		"_": {core.Mijin, "_", regexp.MustCompile(`^\w\w*`)},
 
-		"NA":   {core.Mainnet, "NA", regexp.MustCompile("^NA\\w*")},
-		"NABC": {core.Mainnet, "NABC", regexp.MustCompile("^NABC\\w*")},
-		"_ABC": {core.Mainnet, "_ABC", regexp.MustCompile("^\\wABC\\w*")},
+		"NA":   {core.Mainnet, "NA", regexp.MustCompile(`^NA\w*`)},
+		"NABC": {core.Mainnet, "NABC", regexp.MustCompile(`^NABC\w*`)},
+		"_ABC": {core.Mainnet, "_ABC", regexp.MustCompile(`^\wABC\w*`)},
 
 		"-T-D-2-3-4---": {
 			core.Testnet,
 			"TD234",
-			regexp.MustCompile("^TD234\\w*"),
+			regexp.MustCompile(`^TD234\w*`),
 		},
 		"TA____-BB____-C_CC___-D__D_D": {
 			core.Testnet,
 			"TA____BB____C_CC___D__D_D",
-			regexp.MustCompile("^TA\\w\\w\\w\\wBB\\w\\w\\w\\wC\\wCC\\w\\w\\wD\\w\\wD\\wD\\w*"),
+			regexp.MustCompile(`^TA\w\w\w\wBB\w\w\w\wC\wCC\w\w\wD\w\wD\wD\w*`),
 		},
 	} {
 		t.Run(k, func(t *testing.T) {
@@ -124,8 +124,8 @@ func TestExcludeSelector_Pass_false(t *testing.T) {
 
 func TestPrefixSelector_Pass_true(t *testing.T) {
 	for k, v := range map[string](*regexp.Regexp){
-		"TABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA": regexp.MustCompile("^TABC\\w*"),
-		"TAAAAABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF2345": regexp.MustCompile("^TA\\wAA\\wBB\\w*"),
+		"TABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA": regexp.MustCompile(`^TABC\w*`),
+		"TAAAAABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF2345": regexp.MustCompile(`^TA\wAA\wBB\w*`),
 	} {
 		t.Run(k, func(t *testing.T) {
 			addr, _ := keypair.ParseAddress(k)
@@ -136,13 +136,13 @@ func TestPrefixSelector_Pass_true(t *testing.T) {
 
 func TestPrefixSelector_Pass_false(t *testing.T) {
 	for k, v := range map[string](*regexp.Regexp){
-		"TBACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA": regexp.MustCompile("^TABC\\w*"),
-		"TACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA": regexp.MustCompile("^TABC\\w*"),
-		"TCABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA": regexp.MustCompile("^TABC\\w*"),
+		"TBACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA": regexp.MustCompile(`^TABC\w*`),
+		"TACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA": regexp.MustCompile(`^TABC\w*`),
+		"TCABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA": regexp.MustCompile(`^TABC\w*`),
 
-		"T2AAAABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF2345": regexp.MustCompile("^TA\\wAA\\wBB\\w*"),
-		"TAAA3ABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF2345": regexp.MustCompile("^TA\\wAA\\wBB\\w*"),
-		"TAAAAAB4BBBBCCCCCCDDDDDDEEEEEEFFFFFF2345": regexp.MustCompile("^TA\\wAA\\wBB\\w*"),
+		"T2AAAABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF2345": regexp.MustCompile(`^TA\wAA\wBB\w*`),
+		"TAAA3ABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF2345": regexp.MustCompile(`^TA\wAA\wBB\w*`),
+		"TAAAAAB4BBBBCCCCCCDDDDDDEEEEEEFFFFFF2345": regexp.MustCompile(`^TA\wAA\wBB\w*`),
 	} {
 		t.Run(k, func(t *testing.T) {
 			addr, _ := keypair.ParseAddress(k)

--- a/pkg/vanity/vanity.go
+++ b/pkg/vanity/vanity.go
@@ -12,11 +12,11 @@ import (
 // StartSearch starts search process for vanity account address that satisfies a given selector
 func StartSearch(chain core.Chain, selector Selector, ch chan<- keypair.KeyPair) {
 	for {
-		pair := keypair.Gen()
-		if !selector.Pass(pair.Address(chain)) {
+		pr := keypair.Gen()
+		if !selector.Pass(pr.Address(chain)) {
 			continue
 		}
-		ch <- pair
+		ch <- pr
 		return
 	}
 }

--- a/pkg/vanity/vanity_test.go
+++ b/pkg/vanity/vanity_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestStartSearch(t *testing.T) {
 	rs := make(chan keypair.KeyPair)
-	s, _ := NewPrefixSelector(core.Testnet, "TA")
-	go StartSearch(core.Testnet, s, rs)
-	p := <-rs
-	assert.True(t, strings.HasPrefix(p.Address(core.Testnet).String(), "TA"))
+	sel, _ := NewPrefixSelector(core.Testnet, "TA")
+	go StartSearch(core.Testnet, sel, rs)
+	pr := <-rs
+	assert.True(t, strings.HasPrefix(pr.Address(core.Testnet).String(), "TA"))
 }


### PR DESCRIPTION
Write unittests, related to #112.

----

<!--- Put an `x` in all the boxes that apply -->

- [x] I have read the `CONTRIBUTING.md` and `make ci` passes on my machine.
- [x] I have updated the user manual accordingly.
- [x] I have added tests to cover my changes.
