### PR TITLE
Lack of `info` subcommand for account

### DIFF
--- a/cmd/nem/main.go
+++ b/cmd/nem/main.go
@@ -19,8 +19,6 @@ import (
 
 	"bufio"
 
-	"bytes"
-
 	"github.com/nem-toolchain/nem-toolchain/pkg/core"
 	"github.com/nem-toolchain/nem-toolchain/pkg/keypair"
 	"github.com/nem-toolchain/nem-toolchain/pkg/vanity"
@@ -136,7 +134,7 @@ func generateAction(c *cli.Context) error {
 
 	num := c.Uint("number")
 	for i := uint(0); i < num; i++ {
-		printAccountDetails(ch, keypair.Gen(nil))
+		printAccountDetails(ch, keypair.Gen())
 		fmt.Println("----")
 	}
 
@@ -236,7 +234,7 @@ func info(c *cli.Context) error {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
-	pair := keypair.Gen(bytes.NewReader(pkBytes))
+	pair := keypair.FromSeed(pkBytes)
 	if c.Bool("address-only") {
 		printAddress(ch, pair)
 	}
@@ -284,7 +282,7 @@ func countActualRate(workers uint) float64 {
 func countKeyPairs(milliseconds time.Duration, res chan int) {
 	timeout := time.After(time.Millisecond * milliseconds)
 	for count := 0; ; count++ {
-		keypair.Gen(nil).Address(core.Mainnet)
+		keypair.Gen().Address(core.Mainnet)
 		select {
 		case <-timeout:
 			res <- count
@@ -319,7 +317,7 @@ func timeInSeconds(val float64) string {
 func printAccountDetails(chain core.Chain, pair keypair.KeyPair) {
 	printAddress(chain, pair)
 	printPublicKey(pair)
-	fmt.Println("Private key:", hex.EncodeToString(pair.Private))
+	printPrivateKey(pair)
 }
 
 func printAddress(chain core.Chain, pair keypair.KeyPair) {
@@ -328,4 +326,8 @@ func printAddress(chain core.Chain, pair keypair.KeyPair) {
 
 func printPublicKey(pair keypair.KeyPair) {
 	fmt.Println("Public key:", hex.EncodeToString(pair.Public))
+}
+
+func printPrivateKey(pair keypair.KeyPair) {
+	fmt.Println("Private key:", hex.EncodeToString(pair.Private))
 }

--- a/cmd/nem/main.go
+++ b/cmd/nem/main.go
@@ -223,6 +223,7 @@ func info(c *cli.Context) error {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
+	fmt.Println("Enter private key: ")
 	reader := bufio.NewReader(os.Stdin)
 	privateKeyStr, err := reader.ReadString('\n')
 	if err != nil {
@@ -235,15 +236,15 @@ func info(c *cli.Context) error {
 	}
 
 	pair := keypair.FromSeed(pkBytes)
-	if c.Bool("address-only") {
+	if c.Bool("address") {
 		printAddress(ch, pair)
 	}
 
-	if c.Bool("public-only") {
+	if c.Bool("public") {
 		printPublicKey(pair)
 	}
 
-	if !c.Bool("address-only") && !c.Bool("public-only") {
+	if !c.Bool("address") && !c.Bool("public") {
 		printAccountDetails(ch, pair)
 	}
 

--- a/cmd/nem/main.go
+++ b/cmd/nem/main.go
@@ -110,11 +110,11 @@ func main() {
 					Action: info,
 					Flags: []cli.Flag{
 						cli.BoolFlag{
-							Name:  "address-only, a",
+							Name:  "address",
 							Usage: "Show address for supplied private key",
 						},
 						cli.BoolFlag{
-							Name:  "public-only, p",
+							Name:  "public",
 							Usage: "Show public key for supplied private key",
 						},
 					},

--- a/pkg/keypair/keypair.go
+++ b/pkg/keypair/keypair.go
@@ -5,6 +5,8 @@
 package keypair
 
 import (
+	"io"
+
 	"github.com/nem-toolchain/nem-toolchain/pkg/core"
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/ripemd160"
@@ -12,8 +14,8 @@ import (
 )
 
 // Gen generates a new private/public key pair using entropy from crypto rand.
-func Gen() KeyPair {
-	pub, pr, err := ed25519.GenerateKey(nil)
+func Gen(rand io.Reader) KeyPair {
+	pub, pr, err := ed25519.GenerateKey(rand)
 	if err != nil {
 		panic("assert: ed25519 GenerateKey function internal error")
 	}

--- a/pkg/keypair/keypair.go
+++ b/pkg/keypair/keypair.go
@@ -7,6 +7,8 @@ package keypair
 import (
 	"io"
 
+	"bytes"
+
 	"github.com/nem-toolchain/nem-toolchain/pkg/core"
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/ripemd160"
@@ -14,8 +16,18 @@ import (
 )
 
 // Gen generates a new private/public key pair using entropy from crypto rand.
-func Gen(rand io.Reader) KeyPair {
-	pub, pr, err := ed25519.GenerateKey(rand)
+func Gen() KeyPair {
+	return FromSeed(nil)
+}
+
+// FromSeed generates a new private/public key pair using specified seed data
+func FromSeed(seed []byte) KeyPair {
+	var r io.Reader = nil
+	if seed != nil {
+		r = bytes.NewReader(seed)
+	}
+
+	pub, pr, err := ed25519.GenerateKey(r)
 	if err != nil {
 		panic("assert: ed25519 GenerateKey function internal error")
 	}

--- a/pkg/keypair/keypair_test.go
+++ b/pkg/keypair/keypair_test.go
@@ -7,18 +7,15 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"bytes"
-
 	"github.com/nem-toolchain/nem-toolchain/pkg/core"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/ed25519"
 )
 
 func TestKeyPair_Gen(t *testing.T) {
 	pr, _ := hex.DecodeString("2c52aee96f0e30f21c86b3fab7a18e927f579618818e8148e7ded1e01875ef0b")
-	exp, _ := hex.DecodeString("9d1e9d01ab916dbdde0e76ba43df2246575d637db0bca090f46c1abce19a43e3")
-	act, _, _ := ed25519.GenerateKey(bytes.NewReader(pr))
-	assert.Equal(t, exp, []byte(act))
+	exp_pub, _ := hex.DecodeString("9d1e9d01ab916dbdde0e76ba43df2246575d637db0bca090f46c1abce19a43e3")
+	pair := FromSeed(pr)
+	assert.Equal(t, exp_pub, pair.Public)
 }
 
 func TestKeyPair_Address_mainnet(t *testing.T) {

--- a/pkg/vanity/vanity.go
+++ b/pkg/vanity/vanity.go
@@ -12,7 +12,7 @@ import (
 // StartSearch starts search process for vanity account address that satisfies a given selector
 func StartSearch(chain core.Chain, selector Selector, ch chan<- keypair.KeyPair) {
 	for {
-		pr := keypair.Gen(nil)
+		pr := keypair.Gen()
 		if !selector.Pass(pr.Address(chain)) {
 			continue
 		}

--- a/pkg/vanity/vanity.go
+++ b/pkg/vanity/vanity.go
@@ -12,7 +12,7 @@ import (
 // StartSearch starts search process for vanity account address that satisfies a given selector
 func StartSearch(chain core.Chain, selector Selector, ch chan<- keypair.KeyPair) {
 	for {
-		pr := keypair.Gen()
+		pr := keypair.Gen(nil)
 		if !selector.Pass(pr.Address(chain)) {
 			continue
 		}


### PR DESCRIPTION
Related to #139.

----

<!--- Put an `x` in all the boxes that apply -->

- [x] I have read the `CONTRIBUTING.md` and `make ci` passes on my machine.
- [x] I have updated the user manual accordingly.
- [x] I have added tests to cover my changes.